### PR TITLE
Correct LBS-Kan50 to LBS-Kan100

### DIFF
--- a/antibiotics.md
+++ b/antibiotics.md
@@ -11,13 +11,13 @@
 
 ## Preparation of stocks
 
-Antibiotic      | Color                              | Abbr | Concentration (mg/ml) | Solvent | Stock notes
-:--------------:|:----------------------------------:|:----:|:---:|:---------------:|:---------------------
-Carbenicillin   | <font color='orange'>ORANGE</font> | Carb | 100 | dH<sub>2</sub>0 | Filter
-Chloramphenicol | <font color='red'>RED</font>       | Cam  | 25  | 100% ethanol    |  
-Erythromycin    | <font color='green'>GREEN</font>   | Erm  | 10  | 100% ethanol    |  
-Kanamycin       | <font color='blue'>BLUE</font>     | Kan  | 50  | dH<sub>2</sub>0 | Filter
-Tetracycline    | <font color='purple'>PURPLE</font> | Tet  | 10  | 100% ethanol    | Keep dark (foil wrap)
+|   Antibiotic    |               Color                | Abbr | Concentration (mg/ml) |     Solvent     | Stock notes |
+|:---------------:|:----------------------------------:|:----:|:---------------------:|:---------------:|:--|
+|  Carbenicillin  | <font color='orange'>ORANGE</font> | Carb |          100          | dH<sub>2</sub>0 | Filter |
+| Chloramphenicol |    <font color='red'>RED</font>    | Cam  |          25           |  100% ethanol   |   |
+|  Erythromycin   |  <font color='green'>GREEN</font>  | Erm  |          10           |  100% ethanol   |   |
+|    Kanamycin    |   <font color='blue'>BLUE</font>   | Kan  |          50           | dH<sub>2</sub>0 | Filter |
+|  Tetracycline   | <font color='purple'>PURPLE</font> | Tet  |          10           |  100% ethanol   | Keep dark (foil wrap) |
 
 Note that the dry erythromycin is stored at room temperature.
 
@@ -28,22 +28,22 @@ For each stock aliquot approximately 700 μl per microfuge tube and store at -20
 
 ## Working concentrations for *E. coli*
 
-Antibiotic      | Color                              | Final concentration (μg / ml)      | Stock to add per 1 L media
-:--------------:|:----------------------------------:|:----------------------------------:|:-------------------------:
-Carbenicillin   | <font color='orange'>ORANGE</font> | LB-Carb<sup>100</sup>              | 1,000 μl
-Chloramphenicol | <font color='red'>RED</font>       | LB-Cam<sup>25</sup>                | 1,000 μl
-Erythromycin    | <font color='green'>GREEN</font>   | BHI-Erm<sup>150</sup>              | 150 mg dry (or 15 ml)
-Kanamycin       | <font color='blue'>BLUE</font>     | LB-Kan<sup>50</sup>                | 1,000 μl
-Tetracycline    | <font color='purple'>PURPLE</font> | LB-Tet<sup>15</sup>                | 1,500 μl
+|   Antibiotic    |               Color                | Final concentration (μg / ml) | Stock to add per 1 L media |
+|:---------------:|:----------------------------------:|:-----------------------------:|:-:|
+|  Carbenicillin  | <font color='orange'>ORANGE</font> |     LB-Carb<sup>100</sup>     | 1,000 μl |
+| Chloramphenicol |    <font color='red'>RED</font>    |      LB-Cam<sup>25</sup>      | 1,000 μl |
+|  Erythromycin   |  <font color='green'>GREEN</font>  |     BHI-Erm<sup>150</sup>     | 150 mg dry (or 15 ml) |
+|    Kanamycin    |   <font color='blue'>BLUE</font>   |      LB-Kan<sup>50</sup>      | 1,000 μl |
+|  Tetracycline   | <font color='purple'>PURPLE</font> |      LB-Tet<sup>15</sup>      | 1,500 μl |
 
 
 
 ## Working concentrations for *V. fischeri*
 
-Antibiotic      | Color                              | Final concentration (μg / ml)      | Stock to add per 1 L media
-:--------------:|:----------------------------------:|:----------------------------------:|:-------------------------:
-Carbenicillin   | <font color='orange'>ORANGE</font> | N/A                                |
-Chloramphenicol | <font color='red'>RED</font>       | LBS-Cam<sup>5</sup>                | 200 μl
-Erythromycin    | <font color='green'>GREEN</font>   | LBS-Erm<sup>5</sup>                | 500 μl
-Kanamycin       | <font color='blue'>BLUE</font>     | LBS-Kan<sup>50</sup>                | 2,000 μl
-Tetracycline    | <font color='purple'>PURPLE</font> | LBS-Tet<sup>15</sup>                | 500 μl
+|   Antibiotic    |               Color                | Final concentration (μg / ml) | Stock to add per 1 L media |
+|:---------------:|:----------------------------------:|:-----------------------------:|:-:|
+|  Carbenicillin  | <font color='orange'>ORANGE</font> |              N/A              |   |
+| Chloramphenicol |    <font color='red'>RED</font>    |      LBS-Cam<sup>5</sup>      | 200 μl |
+|  Erythromycin   |  <font color='green'>GREEN</font>  |      LBS-Erm<sup>5</sup>      | 500 μl |
+|    Kanamycin    |   <font color='blue'>BLUE</font>   |     LBS-Kan<sup>100</sup>     | 2,000 μl |
+|  Tetracycline   | <font color='purple'>PURPLE</font> |     LBS-Tet<sup>15</sup>      | 500 μl |


### PR DESCRIPTION
The only substantive correction here is changing LBS-Kan50 to LBS-Kan100.

The amount of kanamycin stock added (2,000) already yielded Kan100 as the concentration, but Kan50 was incorrectly listed.

The other changes should not affect the markdown rendering... just make it look prettier in the text file.